### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ CORE_DEFINE := -DWANT_LYNX_EMU
 NEED_CRC32 = 1
 
 TARGET_NAME := mednafen_lynx
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -5,6 +5,11 @@ FAST = 1
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(TARGET_ARCH),arm)
 ANDROID_FLAGS := -DANDROID_ARM
 LOCAL_ARM_MODE := arm

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -807,7 +807,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = MEDNAFEN_CORE_NAME;
-   info->library_version  = MEDNAFEN_CORE_VERSION;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = MEDNAFEN_CORE_VERSION GIT_VERSION;
    info->need_fullpath    = true;
    info->valid_extensions = MEDNAFEN_CORE_EXTENSIONS;
    info->block_extract    = false;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.