### PR TITLE
Updated internal core name to Beetle Handy

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -64,7 +64,7 @@ static void set_basename(const char *path)
 }
 
 #define MEDNAFEN_CORE_NAME_MODULE "lynx"
-#define MEDNAFEN_CORE_NAME "Beetle Lynx"
+#define MEDNAFEN_CORE_NAME "Beetle Handy"
 #define MEDNAFEN_CORE_VERSION "v1.24.0"
 #define MEDNAFEN_CORE_EXTENSIONS "lnx|o"
 #define MEDNAFEN_CORE_TIMING_FPS 75.0


### PR DESCRIPTION
Previously was internally Beetle Lynx. This change will result in changing the save/state/cheat directory names and the config/override names, and thus this PR should be rejected if that's deemed too troublesome for the gain.