### PR TITLE
Adding Spanish translation to the core.

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -72,7 +72,7 @@ struct retro_core_option_definition option_defs_us[] = {
 
    {
       "lynx_pix_format",
-      "Color Format (Restart)",
+      "Color Format (Restart Required)",
       "",
       {
          { "16", "16-Bit (RGB565)" },
@@ -96,7 +96,7 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
    NULL,           /* RETRO_LANGUAGE_JAPANESE */
    NULL,           /* RETRO_LANGUAGE_FRENCH */
-   NULL,           /* RETRO_LANGUAGE_SPANISH */
+   option_defs_es, /* RETRO_LANGUAGE_SPANISH */
    NULL,           /* RETRO_LANGUAGE_GERMAN */
    NULL,           /* RETRO_LANGUAGE_ITALIAN */
    NULL,           /* RETRO_LANGUAGE_DUTCH */

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -1,4 +1,4 @@
-#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
 #define LIBRETRO_CORE_OPTIONS_INTL_H__
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
@@ -42,6 +42,40 @@ extern "C" {
 /* RETRO_LANGUAGE_FRENCH */
 
 /* RETRO_LANGUAGE_SPANISH */
+
+struct retro_core_option_definition option_defs_es[] = {
+
+   /* These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
+    * Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
+    * Adding more variables and rearranging them is safe. */
+
+   {
+      "lynx_rot_screen",
+      "Rotación automática de pantalla",
+      "Rota automáticamente la orientación de la pantalla y los controles en aquellos juegos que lo necesiten. Al seleccionar la opción «Manual», la rotación de pantalla se podrá ajustar al pulsar el botón Select, en caso contrario, se puede asignar una rotación fija de 0º, 90º, 180º o 270º (en el sentido contrario al de las agujas del reloj).",
+      {
+         { "auto", "Automática" },
+         { "manual", "Manual" },
+         { "0",    NULL },
+         { "90",   "90º" },
+         { "180",  "180º" },
+         { "270",  "270º" },
+         { NULL, NULL},
+      },
+      "auto",
+   },
+
+   {
+      "lynx_pix_format",
+      "Formato de color (es necesario reiniciar)",
+      "",
+      {
+         { "16", "16 bits (RGB565)" },
+         { "32", "32 bits (RGB8888)" },
+         { NULL, NULL},
+      },
+      "16",
+   },
 
 /* RETRO_LANGUAGE_GERMAN */
 


### PR DESCRIPTION
Also updating the word "(Restart)" so it matches the current unified term on US texts.