### PR TITLE
Don't tell software this is emulation

### DIFF
--- a/mednafen/lynx/mikie.cpp
+++ b/mednafen/lynx/mikie.cpp
@@ -1412,7 +1412,8 @@ uint8 CMikie::Peek(uint32 addr)
 // Register to let programs know handy is running
 
 		case (0xfd97&0xff):
-			return 0x42;
+			// return 0x42;
+			break;
 
 // Errors on illegal location accesses
 


### PR DESCRIPTION
Handy (and thus Mednafen Lynx and the Beetle Lynx core) includes a feature where the emulator will deliberately respond differently from real hardware on a specific invalid register access. The intention is to allow software to detect that it's running emulated. This is (only?) used by the aftermarket title Zaku (No-Intro: `Zaku (USA) (Unl).lnx`) to lock up on Handy and derivatives. If there are ethical concerns, it's worth noting that the game has not been available to purchase from its original developers/publishers in years.

I don't see any particular gains to keeping this feature in RetroArch since it's explicitly inaccurate and only being used to break compatibility. It was already removed from libretro-handy in libretro/libretro-handy#62.